### PR TITLE
Add documentation and UI tip for font subsetting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ https://amio.github.io/embedded-google-fonts/
 
 ![Embedded Google Fonts Screenshot][screenshot]
 
+### Tips
+
+#### Font Subsetting
+
+You can use the `&text=` query parameter to only load a subset of font characters, which can significantly reduce the CSS file size.
+
+Example: `https://fonts.googleapis.com/css2?family=Dancing+Script:wght@700&display=swap&text=abc`
+
 ### License
 
 MIT

--- a/index.css
+++ b/index.css
@@ -128,6 +128,18 @@ dd {
   margin-right: 1em;
 }
 
+.tip {
+  font-size: 0.75rem;
+  opacity: 0.5;
+  padding-top: 0;
+}
+
+.tip code {
+  font-family: monospace;
+  background: #f5f5f5;
+  padding: 2px 4px;
+}
+
 textarea {
   width: 100%;
   height: 300px;

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <meta charset="utf-8">
     <title>Embedded Google Fonts</title>
     <meta name="description" content="Embed base64 encoded google fonts into css">
     <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
@@ -29,6 +30,9 @@
         <dd>
           <input id="css-url" class="mdl-textfield" type="text" autofocus />
           <button id="example-btn" class="mdl-button btn-flat">example</button>
+        </dd>
+        <dd class="tip">
+          Tip: append <code>&amp;text=abc</code> to only load subset of characters.
         </dd>
       </dl>
       <dl id="step-iii">


### PR DESCRIPTION
This change addresses the request to document font subsetting using the `&text=` parameter. It adds a "Tips" section to README.md and a subtle UI tip in the application itself to make the feature discoverable and easy to use. I also added a charset meta tag to ensure arrows in the UI are rendered correctly.

---
*PR created automatically by Jules for task [16767610348710110265](https://jules.google.com/task/16767610348710110265) started by @amio*