### PR TITLE
Add loading indicator and copy button with feedback

### DIFF
--- a/index.css
+++ b/index.css
@@ -191,3 +191,31 @@ textarea:focus, .loaded textarea {
 .github-link:hover {
   opacity: 1
 }
+
+.hidden {
+  display: none !important;
+}
+
+#loader {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid rgba(245, 85, 85, 0.3);
+  border-radius: 50%;
+  border-top-color: #F55;
+  animation: spin 1s ease-in-out infinite;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+#copy-btn {
+  margin-left: 1rem;
+}
+
+#copy-btn.copy-success {
+  color: #4CAF50;
+}

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <title>Embedded Google Fonts</title>
     <meta name="description" content="Embed base64 encoded google fonts into css">
     <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
-    <link rel="stylesheet" hrel="font-roboto.css" />
+    <link rel="stylesheet" href="font-roboto.css" />
     <link rel="stylesheet" href="index.css" />
   </head>
   <body>
@@ -39,6 +39,8 @@
         <dt>
           <span class="step-count">3</span>
           <span id="step-iii-hint">Waiting for a valid google font css url... ↑↑↑</span>
+          <span id="loader" class="hidden"></span>
+          <button id="copy-btn" class="mdl-button btn-flat hidden">Copy</button>
         </dt>
         <dd>
           <textarea name="result" id="result" spellcheck="false" resize="false"></textarea>

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@
   var resultTextarea = document.getElementById('result')
   var stepIII = document.getElementById('step-iii')
   var stepIIIHint = document.getElementById('step-iii-hint')
+  var loader = document.getElementById('loader')
+  var copyBtn = document.getElementById('copy-btn')
 
   var exampleButton = document.getElementById('example-btn')
   var exampleURL = 'https://fonts.googleapis.com/icon?family=Material+Icons'
@@ -29,10 +31,18 @@
       return
     }
 
+    loader.classList.remove('hidden')
+    stepIIIHint.classList.add('hidden')
+    copyBtn.classList.add('hidden')
+
     fetchCSS(url)
       .then(embedFonts)
       .then(outputResult)
-      .catch(errorHandler)
+      .catch(function (e) {
+        loader.classList.add('hidden')
+        stepIIIHint.classList.remove('hidden')
+        errorHandler(e)
+      })
   }
 
   function fetchCSS (url) {
@@ -64,9 +74,17 @@
   }
 
   function outputResult (cssText) {
+    loader.classList.add('hidden')
+    stepIIIHint.classList.remove('hidden')
     resultTextarea.value = cssText
     stepIII.className = cssText.length ? 'loaded' : ''
     stepIIIHint.innerText = cssText.length ? hintResult : hintWaiting
+
+    if (cssText.length) {
+      copyBtn.classList.remove('hidden')
+    } else {
+      copyBtn.classList.add('hidden')
+    }
   }
 
   function errorHandler (e) {
@@ -86,6 +104,18 @@
     })
 
     document.getElementById('step-ii-label').addEventListener('click', reset)
+
+    copyBtn.addEventListener('click', function () {
+      navigator.clipboard.writeText(resultTextarea.value).then(function () {
+        var originalText = copyBtn.innerText
+        copyBtn.innerText = '✔'
+        copyBtn.classList.add('copy-success')
+        setTimeout(function () {
+          copyBtn.innerText = originalText
+          copyBtn.classList.remove('copy-success')
+        }, 1000)
+      })
+    })
   }
 
   function reset () {


### PR DESCRIPTION
The user requested several UI improvements to the Embedded Google Fonts application:
1. A loading indicator during CSS generation.
2. A "Copy" button after generation is complete.
3. Brief visual feedback (green checkmark) after a successful copy.

I implemented these features by:
- Adding `#loader` and `#copy-btn` to the HTML structure of Step 3.
- Styling the loader as a spinning circle and the copy button with Material Design-inspired styles in the CSS.
- Adding JavaScript logic to toggle the loader's visibility during the asynchronous font embedding process and to show the copy button once finished.
- Implementing the copy functionality using the `navigator.clipboard` API, with a 1-second transformation of the button's text and color upon success.
- Additionally, I fixed an existing typo in `index.html` that prevented the Roboto font from loading correctly.

Verification was performed by running a local HTTP server and using a Playwright script to capture and inspect screenshots of the loading, loaded, and success states.

---
*PR created automatically by Jules for task [1492586503263491386](https://jules.google.com/task/1492586503263491386) started by @amio*