### PR TITLE
Modernize UI Buttons and Copy Feedback

### DIFF
--- a/index.css
+++ b/index.css
@@ -68,56 +68,37 @@ input, textarea {
 }
 
 .mdl-button {
-  height: 38px;
-  line-height: 38px;
-  padding: 0 24px;
+  height: 32px;
+  line-height: 32px;
+  padding: 0 12px;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 500;
   text-transform: none;
-  border: 2px solid #F55;
-  border-radius: 100px;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  border: 1px solid #EEE;
+  border-radius: 8px;
+  transition: all 0.2s ease-out;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   background-color: #FFF;
-  color: #F55;
-  outline: none;
-  box-shadow: 0 4px 6px rgba(245, 85, 85, 0.12);
-  letter-spacing: 0.5px;
-}
-
-.mdl-button:hover {
-  background-color: #F55;
-  color: #FFF;
-  box-shadow: 0 6px 15px rgba(245, 85, 85, 0.25);
-  transform: translateY(-1px);
-}
-
-.mdl-button:active {
-  transform: translateY(1px);
-  box-shadow: 0 2px 4px rgba(245, 85, 85, 0.2);
+  color: #333;
 }
 
 .btn-flat {
-  background-color: #FFF0F0;
+  background-color: transparent;
   border-color: transparent;
   color: #F55;
-  box-shadow: none;
 }
 
 .btn-flat:hover {
-  background-color: #FFE4E4;
+  background-color: #FFF0F0;
   border-color: #F55;
-  color: #F55;
-  transform: none;
-  box-shadow: none;
 }
 
 .copy-success-icon {
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
   fill: currentColor;
 }
 
@@ -254,12 +235,4 @@ textarea:focus, .loaded textarea {
 #copy-btn.copy-success {
   color: #4CAF50;
   border-color: #4CAF50;
-  background-color: #FFF;
-  box-shadow: 0 4px 6px rgba(76, 175, 80, 0.12);
-}
-
-#copy-btn.copy-success:hover {
-  background-color: #4CAF50;
-  color: #FFF;
-  box-shadow: 0 6px 15px rgba(76, 175, 80, 0.25);
 }

--- a/index.css
+++ b/index.css
@@ -68,37 +68,56 @@ input, textarea {
 }
 
 .mdl-button {
-  height: 32px;
-  line-height: 32px;
-  padding: 0 12px;
+  height: 38px;
+  line-height: 38px;
+  padding: 0 24px;
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 600;
   text-transform: none;
-  border: 1px solid #EEE;
-  border-radius: 8px;
-  transition: all 0.2s ease-out;
+  border: 2px solid #F55;
+  border-radius: 100px;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   background-color: #FFF;
-  color: #333;
+  color: #F55;
+  outline: none;
+  box-shadow: 0 4px 6px rgba(245, 85, 85, 0.12);
+  letter-spacing: 0.5px;
+}
+
+.mdl-button:hover {
+  background-color: #F55;
+  color: #FFF;
+  box-shadow: 0 6px 15px rgba(245, 85, 85, 0.25);
+  transform: translateY(-1px);
+}
+
+.mdl-button:active {
+  transform: translateY(1px);
+  box-shadow: 0 2px 4px rgba(245, 85, 85, 0.2);
 }
 
 .btn-flat {
-  background-color: transparent;
+  background-color: #FFF0F0;
   border-color: transparent;
   color: #F55;
+  box-shadow: none;
 }
 
 .btn-flat:hover {
-  background-color: #FFF0F0;
+  background-color: #FFE4E4;
   border-color: #F55;
+  color: #F55;
+  transform: none;
+  box-shadow: none;
 }
 
 .copy-success-icon {
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
   fill: currentColor;
 }
 
@@ -235,4 +254,12 @@ textarea:focus, .loaded textarea {
 #copy-btn.copy-success {
   color: #4CAF50;
   border-color: #4CAF50;
+  background-color: #FFF;
+  box-shadow: 0 4px 6px rgba(76, 175, 80, 0.12);
+}
+
+#copy-btn.copy-success:hover {
+  background-color: #4CAF50;
+  color: #FFF;
+  box-shadow: 0 6px 15px rgba(76, 175, 80, 0.25);
 }

--- a/index.css
+++ b/index.css
@@ -68,22 +68,38 @@ input, textarea {
 }
 
 .mdl-button {
-  height: 36px;
-  line-height: 36px;
-  padding: 0 16px;
+  height: 32px;
+  line-height: 32px;
+  padding: 0 12px;
   font-size: 14px;
-  font-weight: bold;
-  text-transform: uppercase;
-  border: none;
+  font-weight: 500;
+  text-transform: none;
+  border: 1px solid #EEE;
+  border-radius: 8px;
   transition: all 0.2s ease-out;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #FFF;
+  color: #333;
 }
 
 .btn-flat {
   background-color: transparent;
+  border-color: transparent;
+  color: #F55;
 }
 
 .btn-flat:hover {
-  background-color: #EEE;
+  background-color: #FFF0F0;
+  border-color: #F55;
+}
+
+.copy-success-icon {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
 }
 
 /*
@@ -218,4 +234,5 @@ textarea:focus, .loaded textarea {
 
 #copy-btn.copy-success {
   color: #4CAF50;
+  border-color: #4CAF50;
 }

--- a/index.html
+++ b/index.html
@@ -40,7 +40,12 @@
           <span class="step-count">3</span>
           <span id="step-iii-hint">Waiting for a valid google font css url... ↑↑↑</span>
           <span id="loader" class="hidden"></span>
-          <button id="copy-btn" class="mdl-button btn-flat hidden">Copy</button>
+          <button id="copy-btn" class="mdl-button btn-flat hidden">
+            <span class="btn-text">Copy</span>
+            <svg class="copy-success-icon hidden" viewBox="0 0 24 24">
+              <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/>
+            </svg>
+          </button>
         </dt>
         <dd>
           <textarea name="result" id="result" spellcheck="false" resize="false"></textarea>

--- a/index.js
+++ b/index.js
@@ -107,11 +107,14 @@
 
     copyBtn.addEventListener('click', function () {
       navigator.clipboard.writeText(resultTextarea.value).then(function () {
-        var originalText = copyBtn.innerText
-        copyBtn.innerText = '✔'
+        var btnText = copyBtn.querySelector('.btn-text')
+        var successIcon = copyBtn.querySelector('.copy-success-icon')
+        btnText.classList.add('hidden')
+        successIcon.classList.remove('hidden')
         copyBtn.classList.add('copy-success')
         setTimeout(function () {
-          copyBtn.innerText = originalText
+          btnText.classList.remove('hidden')
+          successIcon.classList.add('hidden')
           copyBtn.classList.remove('copy-success')
         }, 1000)
       })


### PR DESCRIPTION
The buttons have been updated from the older Material Design style to a more modern look with 8px border-radius, font-weight 500, and no uppercase transformation. The "Copy" button now correctly hides its text and shows a green SVG checkmark icon for 1 second upon successful copying. The existing logic that hides the copy button during font fetching was confirmed and maintained.

---
*PR created automatically by Jules for task [3345438366497408704](https://jules.google.com/task/3345438366497408704) started by @amio*